### PR TITLE
Implement `readFrom` without the logger argument

### DIFF
--- a/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
+++ b/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
@@ -1,0 +1,22 @@
+package christophedelory.playlist;
+
+import christophedelory.playlist.plp.PLPProvider;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.InputStream;
+
+public abstract class AbstractPlaylistProvider implements SpecificPlaylistProvider
+{
+  protected Log logger;
+
+  public AbstractPlaylistProvider(Class clazz) {
+    this.logger = LogFactory.getLog(clazz);
+  }
+
+  @Override
+  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws Exception {
+    return this.readFrom(in, encoding, logger);
+  }
+
+}

--- a/src/main/java/christophedelory/playlist/SpecificPlaylistProvider.java
+++ b/src/main/java/christophedelory/playlist/SpecificPlaylistProvider.java
@@ -51,6 +51,21 @@ public interface SpecificPlaylistProvider
      */
     ContentType[] getContentTypes();
 
+
+    /**
+     * Reads a playlist from the specified input stream.
+     * When done, the stream remains open.
+     * @param in an input stream. Shall not be <code>null</code>.
+     * @param encoding the content encoding of the input resource, or <code>null</code> if not known.
+     * @return a new playlist instance, or <code>null</code> if the format has been recognized, but the playlist is malformed.
+     * @throws NullPointerException if <code>in</code> is <code>null</code>.
+     * @throws NullPointerException if <code>logger</code> is <code>null</code>.
+     * @throws Exception if any error occurs during the unmarshalling process.
+     * @see SpecificPlaylist#writeTo
+     * @see SpecificPlaylistFactory#readFrom
+     */
+    SpecificPlaylist readFrom(final InputStream in, final String encoding) throws Exception;
+
     /**
      * Reads a playlist from the specified input stream.
      * When done, the stream remains open.
@@ -61,8 +76,9 @@ public interface SpecificPlaylistProvider
      * @throws NullPointerException if <code>in</code> is <code>null</code>.
      * @throws NullPointerException if <code>logger</code> is <code>null</code>.
      * @throws Exception if any error occurs during the unmarshalling process.
-     * @see SpecificPlaylist#writeTo
+     * @see #readFrom(final InputStream in, final String encoding)
      * @see SpecificPlaylistFactory#readFrom
+     * @see SpecificPlaylist#writeTo
      */
     SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception;
 

--- a/src/main/java/christophedelory/playlist/asx/AsxProvider.java
+++ b/src/main/java/christophedelory/playlist/asx/AsxProvider.java
@@ -27,19 +27,14 @@ package christophedelory.playlist.asx;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Windows Media ASX playlist XML format.
@@ -47,7 +42,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 90 $
  * @author Christophe Delory
  */
-public class AsxProvider implements SpecificPlaylistProvider
+public class AsxProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -91,6 +86,11 @@ public class AsxProvider implements SpecificPlaylistProvider
                         },
                         "Windows Media Audio Redirector (WAX)"),
     };
+
+    public AsxProvider()
+    {
+        super(AsxProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/atom/AtomProvider.java
+++ b/src/main/java/christophedelory/playlist/atom/AtomProvider.java
@@ -30,6 +30,9 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.Date;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.asx.AsxProvider;
+import christophedelory.playlist.b4s.B4sProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.atom.Entry;
@@ -42,22 +45,15 @@ import christophedelory.atom.URIContainer;
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.Version;
 import christophedelory.xml.XmlSerializer;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Atom playlist provider.
- * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class AtomProvider implements SpecificPlaylistProvider
+public class AtomProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -71,6 +67,11 @@ public class AtomProvider implements SpecificPlaylistProvider
                         },
                         "Atom Document"),
     };
+
+    public AtomProvider()
+    {
+        super(AtomProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
+++ b/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
@@ -27,18 +27,15 @@ package christophedelory.playlist.b4s;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.asx.AsxProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * A proprietary XML-based format introduced in Winamp version 3.
@@ -46,7 +43,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class B4sProvider implements SpecificPlaylistProvider
+public class B4sProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -62,6 +59,11 @@ public class B4sProvider implements SpecificPlaylistProvider
                         },
                         "Winamp 3+ Playlist"),
     };
+
+    public B4sProvider()
+    {
+        super(B4sProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
+++ b/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
@@ -27,25 +27,22 @@ package christophedelory.playlist.hypetape;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.b4s.B4sProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Hypetape XML playlist format.
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class HypetapeProvider implements SpecificPlaylistProvider
+public class HypetapeProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -59,6 +56,11 @@ public class HypetapeProvider implements SpecificPlaylistProvider
                         },
                         "Hypetape XML Playlist Format"),
     };
+
+    public HypetapeProvider()
+    {
+        super(HypetapeProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/kpl/KplProvider.java
+++ b/src/main/java/christophedelory/playlist/kpl/KplProvider.java
@@ -32,6 +32,9 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.hypetape.HypetapeProvider;
+import org.apache.commons.logging.LogFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -44,13 +47,6 @@ import org.apache.commons.logging.Log;
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.Version;
 
 /**
@@ -60,7 +56,7 @@ import christophedelory.xml.Version;
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class KplProvider implements SpecificPlaylistProvider
+public class KplProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -74,6 +70,11 @@ public class KplProvider implements SpecificPlaylistProvider
                         },
                         "Kalliope PlayList"),
     };
+
+    public KplProvider()
+    {
+        super(KplProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/m3u/M3UProvider.java
+++ b/src/main/java/christophedelory/playlist/m3u/M3UProvider.java
@@ -30,24 +30,20 @@ import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Locale;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.kpl.KplProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * A simple text-based list of the locations of the items, with each item on a new line.
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class M3UProvider implements SpecificPlaylistProvider
+public class M3UProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -92,6 +88,11 @@ public class M3UProvider implements SpecificPlaylistProvider
                         },
                         "Real Audio Metadata (RAM)"),
     };
+
+    public M3UProvider()
+    {
+        super(M3UProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/mpcpl/MPCPLProvider.java
+++ b/src/main/java/christophedelory/playlist/mpcpl/MPCPLProvider.java
@@ -29,17 +29,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.m3u.M3UProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Media Player Classic Playlist (MPCPL) provider.
@@ -47,7 +43,7 @@ import christophedelory.playlist.SpecificPlaylistProvider;
  * @author Christophe Delory
  * @since 0.3.0
  */
-public class MPCPLProvider implements SpecificPlaylistProvider
+public class MPCPLProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -62,6 +58,11 @@ public class MPCPLProvider implements SpecificPlaylistProvider
                         },
                         "Media Player Classic Playlist"),
     };
+
+    public MPCPLProvider()
+    {
+        super(MPCPLProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/pla/PLAProvider.java
+++ b/src/main/java/christophedelory/playlist/pla/PLAProvider.java
@@ -27,17 +27,13 @@ package christophedelory.playlist.pla;
 import java.io.InputStream;
 import java.util.List;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.mpcpl.MPCPLProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Playlist format for iRiver devices.
@@ -45,7 +41,7 @@ import christophedelory.playlist.SpecificPlaylistProvider;
  * @author Christophe Delory
  * @since 0.2.0
  */
-public class PLAProvider implements SpecificPlaylistProvider
+public class PLAProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -59,6 +55,11 @@ public class PLAProvider implements SpecificPlaylistProvider
                         },
                         "iRiver iQuickList File"),
     };
+
+    public PLAProvider()
+    {
+        super(PLAProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/plist/PlistProvider.java
+++ b/src/main/java/christophedelory/playlist/plist/PlistProvider.java
@@ -28,31 +28,27 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.util.Date;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.pla.PLAProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.plist.Array;
 import christophedelory.plist.Dict;
 import christophedelory.plist.Plist;
 import christophedelory.plist.True;
 import christophedelory.xml.Version;
 import christophedelory.xml.XmlSerializer;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The iTunes library format.
  * @version $Revision: 90 $
  * @author Christophe Delory
  */
-public class PlistProvider implements SpecificPlaylistProvider
+public class PlistProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -67,6 +63,11 @@ public class PlistProvider implements SpecificPlaylistProvider
                         },
                         "iTunes Library File"),
     };
+
+    public PlistProvider()
+    {
+        super(PlistProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/plp/PLPProvider.java
+++ b/src/main/java/christophedelory/playlist/plp/PLPProvider.java
@@ -29,17 +29,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.plist.PlistProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The PLP playlist format, which lists locations of files in a standard text format.
@@ -47,8 +43,9 @@ import christophedelory.playlist.SpecificPlaylistProvider;
  * @author Christophe Delory
  * @since 0.2.0
  */
-public class PLPProvider implements SpecificPlaylistProvider
+public class PLPProvider extends AbstractPlaylistProvider
 {
+
     /**
      * A list of compatible content types.
      */
@@ -61,6 +58,10 @@ public class PLPProvider implements SpecificPlaylistProvider
                         },
                         "Sansa Playlist File"),
     };
+
+    public PLPProvider() {
+        super(PLPProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/pls/PLSProvider.java
+++ b/src/main/java/christophedelory/playlist/pls/PLSProvider.java
@@ -29,17 +29,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 
+import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.playlist.m3u.Resource;
 
 /**
@@ -51,7 +45,7 @@ import christophedelory.playlist.m3u.Resource;
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class PLSProvider implements SpecificPlaylistProvider
+public class PLSProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -73,6 +67,11 @@ public class PLSProvider implements SpecificPlaylistProvider
                         },
                         "Winamp PLSv2 Playlist"),
     };
+
+    public PLSProvider()
+    {
+        super(PLSProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
+++ b/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
@@ -30,18 +30,12 @@ import java.io.StringReader;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 
+import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.Version;
 
 /**
@@ -50,7 +44,7 @@ import christophedelory.xml.Version;
  * @author Christophe Delory
  * @since 0.3.0
  */
-public class RmpProvider implements SpecificPlaylistProvider
+public class RmpProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -65,6 +59,11 @@ public class RmpProvider implements SpecificPlaylistProvider
                         },
                         "Real Metadata Package (RMP)"),
     };
+
+    public RmpProvider()
+    {
+        super(RmpProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/rss/RSSProvider.java
+++ b/src/main/java/christophedelory/playlist/rss/RSSProvider.java
@@ -30,18 +30,13 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.Date;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.pls.PLSProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.rss.Channel;
 import christophedelory.rss.Enclosure;
 import christophedelory.rss.Item;
@@ -55,7 +50,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 92 $
  * @author Christophe Delory
  */
-public class RSSProvider implements SpecificPlaylistProvider
+public class RSSProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -74,6 +69,11 @@ public class RSSProvider implements SpecificPlaylistProvider
      * Specifies that the output RSS shall make use of the RSS Media extension (and not of the default enclosure capability).
      */
     private boolean _useRSSMedia = false;
+
+    public RSSProvider()
+    {
+        super(RSSProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/smil/SmilProvider.java
+++ b/src/main/java/christophedelory/playlist/smil/SmilProvider.java
@@ -27,18 +27,13 @@ package christophedelory.playlist.smil;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.rss.RSSProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
 
 /**
@@ -47,7 +42,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 90 $
  * @author Christophe Delory
  */
-public class SmilProvider implements SpecificPlaylistProvider
+public class SmilProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -64,6 +59,11 @@ public class SmilProvider implements SpecificPlaylistProvider
                         },
                         "Synchronized Multimedia Integration Language (SMIL)"),
     };
+
+    public SmilProvider()
+    {
+        super(SmilProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/wpl/WplProvider.java
+++ b/src/main/java/christophedelory/playlist/wpl/WplProvider.java
@@ -27,17 +27,13 @@ package christophedelory.playlist.wpl;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
+import christophedelory.playlist.smil.SmilProvider;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Playlist;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
 
 /**
@@ -45,7 +41,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class WplProvider implements SpecificPlaylistProvider
+public class WplProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -61,6 +57,11 @@ public class WplProvider implements SpecificPlaylistProvider
                         },
                         "Windows Media Player Playlist (WPL)"),
     };
+
+    public WplProvider()
+    {
+        super(WplProvider.class);
+    }
 
     @Override
     public String getId()

--- a/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
+++ b/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
@@ -27,17 +27,12 @@ package christophedelory.playlist.xspf;
 import java.io.InputStream;
 import java.io.StringReader;
 
+import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
 import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
-import christophedelory.playlist.AbstractPlaylistComponent;
-import christophedelory.playlist.Media;
-import christophedelory.playlist.Parallel;
-import christophedelory.playlist.Sequence;
-import christophedelory.playlist.SpecificPlaylist;
-import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
 
 /**
@@ -48,7 +43,7 @@ import christophedelory.xml.XmlSerializer;
  * @version $Revision: 91 $
  * @author Christophe Delory
  */
-public class XspfProvider implements SpecificPlaylistProvider
+public class XspfProvider extends AbstractPlaylistProvider
 {
     /**
      * A list of compatible content types.
@@ -63,6 +58,11 @@ public class XspfProvider implements SpecificPlaylistProvider
                         },
                         "XML Shareable Playlist Format (XSPF)"),
     };
+
+    public XspfProvider()
+    {
+        super(XspfProvider.class);
+    }
 
     @Override
     public String getId()


### PR DESCRIPTION
Uses the `SpecificPlaylistProvider` class logger instead.