### PR TITLE
Code smell fixes

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,4 @@
+build = "gradle"
+jdkVersion = "15"
+
+ignoreRules = ["PATH_TRAVERSAL_IN"]

--- a/build.gradle
+++ b/build.gradle
@@ -21,21 +21,12 @@ application {
 
 dependencies {
     implementation 'args4j:args4j:2.33'
-    implementation 'org.codehaus.castor:castor-core:1.4.1'
     implementation 'org.codehaus.castor:castor-xml:1.4.1'
     implementation 'commons-logging:commons-logging:1.2'
-    implementation 'asm:asm:3.3.1'
-    implementation 'commons-beanutils:commons-beanutils-core:1.8.3'
-    implementation 'commons-collections:commons-collections:3.2.2'
-    implementation 'commons-jexl:commons-jexl:1.0'
-    implementation 'org.dom4j:dom4j:2.1.4'
-    // https://mvnrepository.com/artifact/xml-apis/xml-apis
-    implementation 'xml-apis:xml-apis:1.4.01'
-    // https://mvnrepository.com/artifact/com.sun.activation/javax.activation
-    implementation 'com.sun.activation:javax.activation:1.2.0'
 
     // JAXB API only
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
+
     //JAXB RI, Jakarta XML Binding
     runtimeOnly 'com.sun.xml.bind:jaxb-impl:2.3.8'
 
@@ -54,7 +45,7 @@ task javadocJar(type: Jar) {
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from sourceSets.main.allSource
-    duplicatesStrategy = 'include'
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 java {

--- a/src/main/java/christophedelory/content/Content.java
+++ b/src/main/java/christophedelory/content/Content.java
@@ -353,7 +353,9 @@ public class Content
      */
     public boolean isValid()
     {
-        return (_connected == null) ? false : _connected.booleanValue();
+        synchronized (this) {
+            return _connected != null && _connected.booleanValue();
+        }
     }
 
     /**
@@ -362,7 +364,6 @@ public class Content
      * @throws IllegalArgumentException if the URL is not absolute.
      * @throws MalformedURLException if a protocol handler for the URL could not be found, or if some other error occurred while constructing the URL.
      * @throws IOException if any I/O error occurs.
-     * @throws SocketTimeoutException if the timeout expires before the connection can be established.
      * @see #getURL
      */
     public void connect() throws IOException
@@ -404,7 +405,7 @@ public class Content
             //InputStream in = conn.getInputStream(); // May throw IOException, UnknownServiceException.
             //conn.getHeaderField();
             final String encoding = conn.getContentEncoding(); // May be null.
-            final long length = (long) conn.getContentLength(); // May be negative.
+            final long length = conn.getContentLength(); // May be negative.
             final String type = conn.getContentType(); // May be null.
             final long lastModified = conn.getLastModified(); // 0L or more.
 
@@ -429,7 +430,10 @@ public class Content
                 _lastModified = lastModified;
             }
 
-            _connected = Boolean.TRUE;
+            synchronized(this)
+            {
+                _connected = Boolean.TRUE;
+            }
         }
     }
 
@@ -444,7 +448,7 @@ public class Content
     @Override
     public boolean equals(final Object obj)
     {
-        return (obj == null) ? false : _urlString.equals(obj.toString());
+        return obj != null && _urlString.equals(obj.toString());
     }
 
     /**

--- a/src/main/java/christophedelory/content/type/ContentType.java
+++ b/src/main/java/christophedelory/content/type/ContentType.java
@@ -141,6 +141,7 @@ public class ContentType extends FileFilter implements Cloneable
      * @see #setDescription
      * @see FileFilter#getDescription
      */
+    @Override
     public String getDescription()
     {
         return _description;
@@ -191,7 +192,7 @@ public class ContentType extends FileFilter implements Cloneable
     @Override
     public boolean accept(final File f)
     {
-        return (f.isDirectory()) ? true : matchExtension(f.getName()); // Throws NullPointerException if f is null.
+        return f.isDirectory() || matchExtension(f.getName()); // Throws NullPointerException if f is null.
     }
 
     /**

--- a/src/main/java/christophedelory/content/type/ContentTypesFileFilter.java
+++ b/src/main/java/christophedelory/content/type/ContentTypesFileFilter.java
@@ -103,6 +103,7 @@ public class ContentTypesFileFilter extends FileFilter
      * @return a description. Shall not be <code>null</code>.
      * @see FileFilter#getDescription
      */
+    @Override
     public String getDescription()
     {
         final StringBuilder sb = new StringBuilder(_title);

--- a/src/main/java/christophedelory/io/IOUtils.java
+++ b/src/main/java/christophedelory/io/IOUtils.java
@@ -24,9 +24,11 @@
  */
 package christophedelory.io;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.io.StringWriter;
 
 /**
@@ -51,7 +53,7 @@ public final class IOUtils
 
         if (encoding == null)
         {
-            reader = new InputStreamReader(in); // Throws NullPointerException if in is null.
+            reader = new InputStreamReader(in, UTF_8); // Throws NullPointerException if in is null.
         }
         else
         {
@@ -62,7 +64,7 @@ public final class IOUtils
         final char[] buffer = new char[512];
         int nb = 0;
 
-        while (-1 != (nb = reader.read(buffer))) // May throw IOException.
+        while ((nb = reader.read(buffer)) != -1) // May throw IOException.
         {
             writer.write(buffer, 0, nb);
         }

--- a/src/main/java/christophedelory/lizzy/AddToPlaylist.java
+++ b/src/main/java/christophedelory/lizzy/AddToPlaylist.java
@@ -109,49 +109,49 @@ public final class AddToPlaylist
      * The playlist type, if specified.
      */
     @Option(name="-t",usage="The output playlist type\nAllowed values: see below",metaVar="type")
-    private volatile String _type = null;
+    private String _type = null;
 
     /**
      * Specifies if the content metadata shall be fetched, if possible.
      */
     @Option(name="-m",usage="Fetch if possible the media content metadata")
-    private volatile boolean _fetchContentMetadata = false;
+    private boolean _fetchContentMetadata = false;
 
     /**
      * The sub-directories shall be recursively scanned.
      */
     @Option(name="-r",usage="Recursively add sub-directories contents")
-    private volatile boolean _recursive = false;
+    private boolean _recursive = false;
 
     /**
      * The output file or URL.
      */
     @Option(name="-o",usage="The output file or URL\nIf missing, a file save dialog is prompted\nIf the output playlist type is not specified (-t), it will be inferred from the output file name extension",metaVar="file/URL")
-    private volatile String _output = null;
+    private String _output = null;
 
     /**
      * Specifies that the marshalled M3U playlist must use the Extension M3U format.
      */
     @Option(name="-m3u:ext",usage="The output M3U playlist must use the Extension M3U format")
-    private volatile boolean _extM3U = false;
+    private boolean _extM3U = false;
 
     /**
      * Specifies that the output RSS shall make use of the RSS Media extension.
      */
     @Option(name="-rss:media",usage="The output RSS playlist must use the RSS Media format")
-    private volatile boolean _useRSSMedia = false;
+    private boolean _useRSSMedia = false;
 
     /**
      * Specifies the disk identifier of the output PLP playlist.
      */
     @Option(name="-plp:disk",usage="The disk identifier of the output PLP playlist\nExamples: HARP, HDD",metaVar="disk")
-    private volatile String _diskSpecifier = null;
+    private String _diskSpecifier = null;
 
     /**
      * The list of input files or directories.
      */
     @Argument(usage="One or more files or directories to add to the output playlist",metaVar="input-files(s)",required=true)
-    private volatile ArrayList<String> _arguments = new ArrayList<String>(); // NOPMD Avoid using implementation types; use the interface instead
+    private ArrayList<String> _arguments = new ArrayList<>(); // NOPMD Avoid using implementation types; use the interface instead
 
     /**
      * The default no-arg constructor shall not be publicly available.
@@ -493,7 +493,7 @@ public final class AddToPlaylist
                             sb.insert(0, '/'); // Shall not throw StringIndexOutOfBoundsException.
                             final String previousFileName = previousFile.getName();
 
-                            if (!"/".equals(previousFileName) && !"\\".equals(previousFileName))
+                            if (!previousFileName.equals("/") && !previousFileName.equals("\\"))
                             {
                                 sb.insert(0, previousFileName); // Shall not throw StringIndexOutOfBoundsException.
                             }

--- a/src/main/java/christophedelory/lizzy/ContentTypeInfo.java
+++ b/src/main/java/christophedelory/lizzy/ContentTypeInfo.java
@@ -218,7 +218,7 @@ public final class ContentTypeInfo
             sb.append("</tbody></table></body></html>");
         }
 
-        System.out.println(sb.toString()); // NOPMD System.out.print is used
+        System.out.println(sb); // NOPMD System.out.print is used
     }
 
     /**

--- a/src/main/java/christophedelory/lizzy/FetchContentMetadata.java
+++ b/src/main/java/christophedelory/lizzy/FetchContentMetadata.java
@@ -61,7 +61,7 @@ public class FetchContentMetadata extends BasePlaylistVisitor
     }
 
     @Override
-    public void beginVisitMedia(final Media target) throws Exception
+    public void beginVisitMedia(final Media target)
     {
         if (target.getSource() != null)
         {

--- a/src/main/java/christophedelory/lizzy/PlaylistToString.java
+++ b/src/main/java/christophedelory/lizzy/PlaylistToString.java
@@ -54,12 +54,9 @@ public class PlaylistToString extends BasePlaylistVisitor
 
     /**
      * Builds a new playlist visitor.
-     * @see BasePlaylistVisitor#BasePlaylistVisitor
      */
     public PlaylistToString()
     {
-        super();
-
         _sb = new StringBuilder();
         _indent = 0;
         _debug = false;
@@ -83,7 +80,7 @@ public class PlaylistToString extends BasePlaylistVisitor
     }
 
     @Override
-    public void beginVisitParallel(final Parallel target) throws Exception
+    public void beginVisitParallel(final Parallel target)
     {
         addIndent();
         _sb.append("PARALLEL(x");
@@ -101,13 +98,13 @@ public class PlaylistToString extends BasePlaylistVisitor
     }
 
     @Override
-    public void endVisitParallel(final Parallel target) throws Exception
+    public void endVisitParallel(final Parallel target)
     {
         _indent -= 2;
     }
 
     @Override
-    public void beginVisitSequence(final Sequence target) throws Exception
+    public void beginVisitSequence(final Sequence target)
     {
         addIndent();
         _sb.append("SEQUENCE(x");
@@ -125,13 +122,13 @@ public class PlaylistToString extends BasePlaylistVisitor
     }
 
     @Override
-    public void endVisitSequence(final Sequence target) throws Exception
+    public void endVisitSequence(final Sequence target)
     {
         _indent -= 2;
     }
 
     @Override
-    public void beginVisitMedia(final Media target) throws Exception
+    public void beginVisitMedia(final Media target)
     {
         addIndent();
         _sb.append("MEDIA(x");

--- a/src/main/java/christophedelory/lizzy/Transcode.java
+++ b/src/main/java/christophedelory/lizzy/Transcode.java
@@ -24,20 +24,7 @@
  */
 package christophedelory.lizzy;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import christophedelory.playlist.Playlist;
 import christophedelory.playlist.SpecificPlaylist;
@@ -47,6 +34,19 @@ import christophedelory.playlist.m3u.M3U;
 import christophedelory.playlist.plp.PLP;
 import christophedelory.playlist.rss.RSSProvider;
 import christophedelory.xml.Version;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
 
 /**
  * Converts a given playlist file to a specified format.
@@ -73,7 +73,7 @@ public final class Transcode
         final URL url = Version.class.getClassLoader().getResource(resourceName); // May throw SecurityException. Throws NullPointerException if resourceName is null.
 
         if (url != null) {
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream())); // May throw IOException. Throws NullPointerException if url is null.
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), UTF_8)); // May throw IOException. Throws NullPointerException if url is null.
 
             final String version = reader.readLine(); // May throw IOException.
             Version.CURRENT = Version.valueOf(version); // Throws NullPointerException if version is null. Should not throw IllegalArgumentException, IndexOutOfBoundsException, NumberFormatException.
@@ -126,55 +126,55 @@ public final class Transcode
      * The playlist type, if specified.
      */
     @Option(name="-t",usage="The output playlist type\nAllowed values: see below\nIf missing, the input playlist type is used",metaVar="type")
-    private volatile String _type = null;
+    private String _type = null;
 
     /**
      * Specifies if the intermediate generic playlist shall be displayed or not.
      */
     @Option(name="-g",usage="Show the intermediate generic playlist")
-    private volatile boolean _showGenericPlaylist = false;
+    private boolean _showGenericPlaylist = false;
 
     /**
      * Specifies if the (parsed) input playlist shall be displayed or not.
      */
     @Option(name="-i",usage="Show the parsed input playlist")
-    private volatile boolean _showInputPlaylist = false;
+    private boolean _showInputPlaylist = false;
 
     /**
      * Specifies if the content metadata shall be fetched, if possible.
      */
     @Option(name="-m",usage="Fetch if possible the media content metadata")
-    private volatile boolean _fetchContentMetadata = false;
+    private boolean _fetchContentMetadata = false;
 
     /**
      * The output file or URL.
      */
     @Option(name="-o",usage="The output file or URL\nIf missing, stdout is used\nIf the output playlist type is not specified (-t), it will be inferred from the output file name extension",metaVar="file/URL")
-    private volatile String _output = null;
+    private String _output = null;
 
     /**
      * Specifies that the marshalled M3U playlist must use the Extension M3U format.
      */
     @Option(name="-m3u:ext",usage="The output M3U playlist must use the Extension M3U format")
-    private volatile boolean _extM3U = false;
+    private boolean _extM3U = false;
 
     /**
      * Specifies that the output RSS shall make use of the RSS Media extension.
      */
     @Option(name="-rss:media",usage="The output RSS playlist must use the RSS Media format")
-    private volatile boolean _useRSSMedia = false;
+    private boolean _useRSSMedia = false;
 
     /**
      * Specifies the disk identifier of the output PLP playlist.
      */
     @Option(name="-plp:disk",usage="The disk identifier of the output PLP playlist\nExamples: HARP, HDD",metaVar="disk")
-    private volatile String _diskSpecifier = null;
+    private String _diskSpecifier = null;
 
     /**
      * The input file or URL.
      */
     @Argument(usage="The input playlist file or URL",metaVar="input-playlist",required=true)
-    private volatile ArrayList<String> _arguments = new ArrayList<String>(); // NOPMD Avoid using implementation types; use the interface instead
+    private ArrayList<String> _arguments = new ArrayList<String>(); // NOPMD Avoid using implementation types; use the interface instead
 
     /**
      * The default no-arg constructor shall not be publicly available.

--- a/src/main/java/christophedelory/player/PlayerSupport.java
+++ b/src/main/java/christophedelory/player/PlayerSupport.java
@@ -55,7 +55,7 @@ public class PlayerSupport implements Cloneable
         VLC_MEDIA_PLAYER,
         WINAMP,
         WINDOWS_MEDIA_PLAYER,
-    };
+    }
 
     /**
      * Returns a string representation of the specified player.

--- a/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
+++ b/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
@@ -8,7 +8,7 @@ import java.io.InputStream;
 
 public abstract class AbstractPlaylistProvider implements SpecificPlaylistProvider
 {
-  protected Log logger;
+  protected final Log logger;
 
   public AbstractPlaylistProvider(Class clazz) {
     this.logger = LogFactory.getLog(clazz);

--- a/src/main/java/christophedelory/playlist/BasePlaylistVisitor.java
+++ b/src/main/java/christophedelory/playlist/BasePlaylistVisitor.java
@@ -32,49 +32,49 @@ package christophedelory.playlist;
 public class BasePlaylistVisitor implements PlaylistVisitor
 {
     @Override
-    public void beginVisitPlaylist(final Playlist target) throws Exception
+    public void beginVisitPlaylist(final Playlist target)
     {
         // No-op.
     }
 
     @Override
-    public void endVisitPlaylist(final Playlist target) throws Exception
+    public void endVisitPlaylist(final Playlist target)
     {
         // No-op.
     }
 
     @Override
-    public void beginVisitParallel(final Parallel target) throws Exception
+    public void beginVisitParallel(final Parallel target)
     {
         // No-op.
     }
 
     @Override
-    public void endVisitParallel(final Parallel target) throws Exception
+    public void endVisitParallel(final Parallel target)
     {
         // No-op.
     }
 
     @Override
-    public void beginVisitSequence(final Sequence target) throws Exception
+    public void beginVisitSequence(final Sequence target)
     {
         // No-op.
     }
 
     @Override
-    public void endVisitSequence(final Sequence target) throws Exception
+    public void endVisitSequence(final Sequence target)
     {
         // No-op.
     }
 
     @Override
-    public void beginVisitMedia(final Media target) throws Exception
+    public void beginVisitMedia(final Media target)
     {
         // No-op.
     }
 
     @Override
-    public void endVisitMedia(final Media target) throws Exception
+    public void endVisitMedia(final Media target)
     {
         // No-op.
     }

--- a/src/main/java/christophedelory/playlist/Playlist.java
+++ b/src/main/java/christophedelory/playlist/Playlist.java
@@ -104,13 +104,13 @@ public class Playlist
         }
 
         @Override
-        public void endVisitParallel(final Parallel target) throws Exception
+        public void endVisitParallel(final Parallel target)
         {
             endVisitTimeContainer(target);
         }
 
         @Override
-        public void endVisitSequence(final Sequence target) throws Exception
+        public void endVisitSequence(final Sequence target)
         {
             endVisitTimeContainer(target);
 

--- a/src/main/java/christophedelory/playlist/PlaylistVisitor.java
+++ b/src/main/java/christophedelory/playlist/PlaylistVisitor.java
@@ -42,72 +42,56 @@ public interface PlaylistVisitor
     /**
      * Starts the visit of the specified playlist.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #endVisitPlaylist
      */
-    void beginVisitPlaylist(final Playlist target) throws Exception;
+    void beginVisitPlaylist(final Playlist target);
 
     /**
      * Finishes the visit of the specified playlist.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #beginVisitPlaylist
      */
-    void endVisitPlaylist(final Playlist target) throws Exception;
+    void endVisitPlaylist(final Playlist target);
 
     /**
      * Starts the visit of the specified parallel timing container.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #endVisitParallel
      */
-    void beginVisitParallel(final Parallel target) throws Exception;
+    void beginVisitParallel(final Parallel target);
 
     /**
      * Finishes the visit of the specified parallel timing container.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #beginVisitParallel
      */
-    void endVisitParallel(final Parallel target) throws Exception;
+    void endVisitParallel(final Parallel target);
 
     /**
      * Starts the visit of the specified sequence.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #endVisitSequence
      */
-    void beginVisitSequence(final Sequence target) throws Exception;
+    void beginVisitSequence(final Sequence target);
 
     /**
      * Finishes the visit of the specified sequence.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #beginVisitSequence
      */
-    void endVisitSequence(final Sequence target) throws Exception;
+    void endVisitSequence(final Sequence target);
 
     /**
      * Starts the visit of the specified media.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #endVisitMedia
      */
-    void beginVisitMedia(final Media target) throws Exception;
+    void beginVisitMedia(final Media target);
 
     /**
      * Finishes the visit of the specified media.
      * @param target the element being visited. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>target</code> is <code>null</code>.
-     * @throws Exception if any error occurs during the visit.
      * @see #beginVisitMedia
      */
-    void endVisitMedia(final Media target) throws Exception;
+    void endVisitMedia(final Media target);
 }

--- a/src/main/java/christophedelory/playlist/SpecificPlaylistProvider.java
+++ b/src/main/java/christophedelory/playlist/SpecificPlaylistProvider.java
@@ -76,7 +76,7 @@ public interface SpecificPlaylistProvider
      * @throws NullPointerException if <code>in</code> is <code>null</code>.
      * @throws NullPointerException if <code>logger</code> is <code>null</code>.
      * @throws Exception if any error occurs during the unmarshalling process.
-     * @see #readFrom(final InputStream in, final String encoding)
+     * @see #readFrom(InputStream, String) 
      * @see SpecificPlaylistFactory#readFrom
      * @see SpecificPlaylist#writeTo
      */

--- a/src/main/java/christophedelory/playlist/asx/AsxProvider.java
+++ b/src/main/java/christophedelory/playlist/asx/AsxProvider.java
@@ -224,11 +224,8 @@ public class AsxProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input ASX elements container.
      * @param container the parent ASX element. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>container</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final AsxElementContainer container, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final AsxElementContainer container, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/asx/Entry.java
+++ b/src/main/java/christophedelory/playlist/asx/Entry.java
@@ -122,7 +122,7 @@ public class Entry extends AsxOrEntryElement
     {
         final String skip = StringUtils.normalize(clientSkip);
 
-        _clientSkip = !("NO".equalsIgnoreCase(skip));
+        _clientSkip = ! "NO".equalsIgnoreCase(skip);
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/atom/AtomPlaylist.java
+++ b/src/main/java/christophedelory/playlist/atom/AtomPlaylist.java
@@ -24,17 +24,17 @@
  */
 package christophedelory.playlist.atom;
 
-import java.io.OutputStream;
-import java.io.StringWriter;
-
 import christophedelory.atom.Entry;
 import christophedelory.atom.Feed;
 import christophedelory.atom.Link;
+import christophedelory.content.Content;
 import christophedelory.playlist.Media;
 import christophedelory.playlist.Playlist;
 import christophedelory.playlist.SpecificPlaylist;
 import christophedelory.playlist.SpecificPlaylistProvider;
 import christophedelory.xml.XmlSerializer;
+import java.io.OutputStream;
+import java.io.StringWriter;
 
 /**
  * An Atom {@link Feed} document wrapper.
@@ -100,7 +100,7 @@ public class AtomPlaylist implements SpecificPlaylist
                 if ((link.getHref() != null) && "enclosure".equals(link.getRel()))
                 {
                     final Media media = new Media(); // NOPMD Avoid instantiating new objects inside loops
-                    final christophedelory.content.Content content = new christophedelory.content.Content(link.getHref()); // NOPMD Avoid instantiating new objects inside loops
+                    final Content content = new Content(link.getHref()); // NOPMD Avoid instantiating new objects inside loops
                     content.setType(link.getType());
 
                     if (link.getLength() != null)

--- a/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
+++ b/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
@@ -121,11 +121,8 @@ public class B4sProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input playlist.
      * @param playlist the parent playlist. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>playlist</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
+++ b/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
@@ -118,11 +118,8 @@ public class HypetapeProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input track list.
      * @param playlist the parent playlist. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>playlist</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/kpl/Info.java
+++ b/src/main/java/christophedelory/playlist/kpl/Info.java
@@ -46,7 +46,7 @@ public class Info
     /**
      * The internal date format.
      */
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US); // Should not throw NullPointerException, IllegalArgumentException.
+    private static final ThreadLocal<DateFormat> dateFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd", Locale.US)); // Should not throw NullPointerException, IllegalArgumentException.
 
     /**
      * The creation day.
@@ -90,10 +90,7 @@ public class Info
 
         if (_creation_day != null)
         {
-            synchronized(DATE_FORMAT)
-            {
-                ret = DATE_FORMAT.format(_creation_day); // Should not throw NullPointerException because of _creation_day.
-            }
+            ret = dateFormat.get().format(_creation_day); // Should not throw NullPointerException because of _creation_day.
         }
 
         return ret;
@@ -116,10 +113,7 @@ public class Info
         }
         else
         {
-            synchronized(DATE_FORMAT)
-            {
-                _creation_day = DATE_FORMAT.parse(day); // May throw ParseException.
-            }
+            _creation_day = dateFormat.get().parse(day); // May throw ParseException.
         }
     }
 
@@ -157,10 +151,7 @@ public class Info
 
         if (_modified_day != null)
         {
-            synchronized(DATE_FORMAT)
-            {
-                ret = DATE_FORMAT.format(_modified_day); // Should not throw NullPointerException because of _modified_day.
-            }
+            ret = dateFormat.get().format(_modified_day); // Should not throw NullPointerException because of _modified_day.
         }
 
         return ret;
@@ -183,10 +174,7 @@ public class Info
         }
         else
         {
-            synchronized(DATE_FORMAT)
-            {
-                _modified_day = DATE_FORMAT.parse(day); // May throw ParseException.
-            }
+            _modified_day = dateFormat.get().parse(day); // May throw ParseException.
         }
     }
 

--- a/src/main/java/christophedelory/playlist/kpl/KplProvider.java
+++ b/src/main/java/christophedelory/playlist/kpl/KplProvider.java
@@ -197,11 +197,8 @@ public class KplProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input list.
      * @param entries the parent list of entries. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>entries</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<Entry> entries, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<Entry> entries, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/m3u/M3UProvider.java
+++ b/src/main/java/christophedelory/playlist/m3u/M3UProvider.java
@@ -198,11 +198,8 @@ public class M3UProvider extends AbstractPlaylistProvider
      * Adds the resources referenced in the specified generic playlist component to the input list.
      * @param resources the resulting list of resources. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>resources</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/mpcpl/MPCPLProvider.java
+++ b/src/main/java/christophedelory/playlist/mpcpl/MPCPLProvider.java
@@ -194,11 +194,8 @@ public class MPCPLProvider extends AbstractPlaylistProvider
      * Adds the resources referenced in the specified generic playlist component to the input list.
      * @param resources the resulting list of resources. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>resources</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/pla/PLA.java
+++ b/src/main/java/christophedelory/playlist/pla/PLA.java
@@ -25,6 +25,7 @@
 package christophedelory.playlist.pla;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,7 +87,7 @@ public class PLA implements SpecificPlaylist
         array[17] = 'A';
 
         final int nbSongs = _filenames.size();
-        array[3] = (byte)((nbSongs & 0x000000ff) >> 0);
+        array[3] = (byte)((nbSongs & 0x000000ff));
         array[2] = (byte)((nbSongs & 0x0000ff00) >> 8);
         array[1] = (byte)((nbSongs & 0x00ff0000) >> 16);
         array[0] = (byte)((nbSongs & 0xff000000) >> 24);
@@ -112,10 +113,10 @@ public class PLA implements SpecificPlaylist
 
             // File index is one-based.
             fileIndex++;
-            array[1] = (byte)((fileIndex & 0x000000ff) >> 0);
+            array[1] = (byte)((fileIndex & 0x000000ff));
             array[0] = (byte)((fileIndex & 0x0000ff00) >> 8);
 
-            final byte[] tmp = filename.getBytes("UTF-16BE"); // Shall not throw UnsupportedEncodingException.
+            final byte[] tmp = filename.getBytes(StandardCharsets.UTF_16BE); // Shall not throw UnsupportedEncodingException.
             System.arraycopy(tmp, 0, array, 2, tmp.length); // May throw IndexOutOfBoundsException. Shall not throw ArrayStoreException, NullPointerException.
 
             out.write(array); // May throw IOException.

--- a/src/main/java/christophedelory/playlist/pla/PLAProvider.java
+++ b/src/main/java/christophedelory/playlist/pla/PLAProvider.java
@@ -25,6 +25,7 @@
 package christophedelory.playlist.pla;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import christophedelory.playlist.*;
@@ -90,7 +91,7 @@ public class PLAProvider extends AbstractPlaylistProvider
 
         // First frame is a header starting with a 32-bit big-endian unsigned integer specifying the number of songs in the playlist.
         // Immediately after this there is an ASCII string "iriver UMS PLA", and that's all for the header frame.
-        final String magic = new String(array, 4, 14, "US-ASCII"); // Shall not throw UnsupportedEncodingException, IndexOutOfBoundsException.
+        final String magic = new String(array, 4, 14, StandardCharsets.US_ASCII); // Shall not throw UnsupportedEncodingException, IndexOutOfBoundsException.
 
         if (!"iriver UMS PLA".equals(magic))
         {
@@ -100,7 +101,7 @@ public class PLAProvider extends AbstractPlaylistProvider
         // In addition, player's own Quick Lists have an apparently superfluous extra string "Quick List" starting from 0x20
         //magic = new String(array, 32, 10); // May equal "Quick List".
 
-        final int nbSongs =   (((int) array[3] & 0x0ff) << 0) |
+        final int nbSongs =   (((int) array[3] & 0x0ff)) |
                         (((int) array[2] & 0x0ff) << 8) |
                         (((int) array[1] & 0x0ff) << 16) |
                         (((int) array[0] & 0x0ff) << 24);
@@ -125,7 +126,7 @@ public class PLAProvider extends AbstractPlaylistProvider
             // As the filesystem type is VFAT, it is encoded as big-endian UTF-16 without a byte order mark.
             // I have not tried whether the player recognizes wider than two-byte characters.
             // Also, I have used only absolute paths, I don't know if relative paths would work.
-            final String songFilename = new String(array, 2, 510, "UTF-16BE"); // Shall not throw UnsupportedEncodingException, IndexOutOfBoundsException. NOPMD Avoid instantiating new objects inside loops
+            final String songFilename = new String(array, 2, 510, StandardCharsets.UTF_16BE); // Shall not throw UnsupportedEncodingException, IndexOutOfBoundsException. NOPMD Avoid instantiating new objects inside loops
 
             // The index and filename are everything there is in a single song frame.
             // Note that the filename must fit into one 512-byte frame.
@@ -151,11 +152,8 @@ public class PLAProvider extends AbstractPlaylistProvider
      * Adds the song file names referenced in the specified generic playlist component to the input list.
      * @param filenames the resulting list of file names. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>filenames</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<String> filenames, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<String> filenames, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/plist/PlistProvider.java
+++ b/src/main/java/christophedelory/playlist/plist/PlistProvider.java
@@ -150,13 +150,9 @@ public class PlistProvider extends AbstractPlaylistProvider
      * @param tracks the list of tracks. Shall not be <code>null</code>.
      * @param playlist the playlist. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>tracks</code> is <code>null</code>.
-     * @throws NullPointerException if <code>playlist</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    private void addToPlaylist(final Dict tracks, final Array playlist, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Dict tracks, final Array playlist, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/plp/PLPProvider.java
+++ b/src/main/java/christophedelory/playlist/plp/PLPProvider.java
@@ -176,11 +176,8 @@ public class PLPProvider extends AbstractPlaylistProvider
      * Adds the song file names referenced in the specified generic playlist component to the input list.
      * @param filenames the resulting list of file names. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>filenames</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<String> filenames, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<String> filenames, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/pls/PLSProvider.java
+++ b/src/main/java/christophedelory/playlist/pls/PLSProvider.java
@@ -311,11 +311,8 @@ public class PLSProvider extends AbstractPlaylistProvider
      * Adds the resources referenced in the specified generic playlist component to the input list.
      * @param resources the resulting list of resources. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>resources</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final List<Resource> resources, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/rmp/Package.java
+++ b/src/main/java/christophedelory/playlist/rmp/Package.java
@@ -56,7 +56,7 @@ public class Package implements SpecificPlaylist
     /**
      * The internal date and time format.
      */
-    private static final DateFormat DATETIME_FORMAT = new SimpleDateFormat("MM/dd/yyyy HH:mm", Locale.US); // Should not throw NullPointerException, IllegalArgumentException.
+    private static final ThreadLocal<DateFormat> datetimeFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("MM/dd/yyyy HH:mm", Locale.US)); // Should not throw NullPointerException, IllegalArgumentException.
 
     /**
      * The provider of this specific playlist.
@@ -266,10 +266,7 @@ public class Package implements SpecificPlaylist
 
         if (_expirationDate != null)
         {
-            synchronized(DATETIME_FORMAT)
-            {
-                ret = DATETIME_FORMAT.format(_expirationDate); // Should not throw NullPointerException because of _expirationDate.
-            }
+            ret = datetimeFormat.get().format(_expirationDate); // Should not throw NullPointerException because of _expirationDate.
         }
 
         return ret;
@@ -285,10 +282,7 @@ public class Package implements SpecificPlaylist
      */
     public void setExpirationDateString(final String expirationDate) throws ParseException
     {
-        synchronized(DATETIME_FORMAT)
-        {
-            _expirationDate = DATETIME_FORMAT.parse(expirationDate); // May throw ParseException. Throws NullPointerException if expirationDate is null.
-        }
+        _expirationDate = datetimeFormat.get().parse(expirationDate); // May throw ParseException. Throws NullPointerException if expirationDate is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
+++ b/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
@@ -135,11 +135,8 @@ public class RmpProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input track list.
      * @param trackList the parent track list. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>trackList</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final Tracklist trackList, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Tracklist trackList, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/smil/Head.java
+++ b/src/main/java/christophedelory/playlist/smil/Head.java
@@ -25,6 +25,7 @@
 package christophedelory.playlist.smil;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -115,7 +116,7 @@ public class Head extends Core
     public boolean removeMetaByName(final String name)
     {
         boolean ret = false;
-        final java.util.Iterator<Meta> iter = _metas.iterator();
+        final Iterator<Meta> iter = _metas.iterator();
 
         while (iter.hasNext())
         {

--- a/src/main/java/christophedelory/playlist/smil/ParamGroup.java
+++ b/src/main/java/christophedelory/playlist/smil/ParamGroup.java
@@ -55,7 +55,7 @@ public class ParamGroup extends Core
      */
     public boolean isSkipContent()
     {
-        return (_skipContent == null) ? false : _skipContent.booleanValue();
+        return _skipContent != null && _skipContent.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/smil/Region.java
+++ b/src/main/java/christophedelory/playlist/smil/Region.java
@@ -288,7 +288,7 @@ public class Region extends Position
      */
     public boolean isSkipContent()
     {
-        return (_skipContent == null) ? false : _skipContent.booleanValue();
+        return _skipContent != null && _skipContent.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/smil/RegistrationPoint.java
+++ b/src/main/java/christophedelory/playlist/smil/RegistrationPoint.java
@@ -82,7 +82,7 @@ public class RegistrationPoint extends Position
      */
     public boolean isSkipContent()
     {
-        return (_skipContent == null) ? false : _skipContent.booleanValue();
+        return _skipContent != null && _skipContent.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/smil/RootLayout.java
+++ b/src/main/java/christophedelory/playlist/smil/RootLayout.java
@@ -197,7 +197,7 @@ public class RootLayout extends Core
      */
     public boolean isSkipContent()
     {
-        return (_skipContent == null) ? false : _skipContent.booleanValue();
+        return _skipContent != null && _skipContent.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/smil/SmilProvider.java
+++ b/src/main/java/christophedelory/playlist/smil/SmilProvider.java
@@ -107,7 +107,7 @@ public class SmilProvider extends AbstractPlaylistProvider
     }
 
     @Override
-    public SpecificPlaylist toSpecificPlaylist(final Playlist playlist) throws Exception
+    public SpecificPlaylist toSpecificPlaylist(final Playlist playlist)
     {
         final Smil ret = new Smil();
         ret.setProvider(this);

--- a/src/main/java/christophedelory/playlist/wpl/Head.java
+++ b/src/main/java/christophedelory/playlist/wpl/Head.java
@@ -24,10 +24,10 @@
  */
 package christophedelory.playlist.wpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import christophedelory.lang.StringUtils;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Contains metadata that applies to the entire playlist.
@@ -178,7 +178,7 @@ public class Head
     public boolean removeMetaByName(final String name)
     {
         boolean ret = false;
-        final java.util.Iterator<Meta> iter = _metas.iterator();
+        final Iterator<Meta> iter = _metas.iterator();
 
         while (iter.hasNext())
         {

--- a/src/main/java/christophedelory/playlist/wpl/WplProvider.java
+++ b/src/main/java/christophedelory/playlist/wpl/WplProvider.java
@@ -129,11 +129,8 @@ public class WplProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input sequence.
      * @param wplSeq the parent sequence. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>wplSeq</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final Seq wplSeq, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Seq wplSeq, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/playlist/xspf/Track.java
+++ b/src/main/java/christophedelory/playlist/xspf/Track.java
@@ -390,7 +390,7 @@ public class Track extends Attribution
             throw new IllegalArgumentException("No application attribute");
         }
 
-        if (!"application".equals(attr.getLocalName()))
+        if (!attr.getLocalName().equals("application"))
         {
             throw new IllegalArgumentException("Unknown attribute");
         }

--- a/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
+++ b/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
@@ -120,11 +120,8 @@ public class XspfProvider extends AbstractPlaylistProvider
      * Adds the specified generic playlist component, and all its childs if any, to the input track list.
      * @param playlist the parent playlist. Shall not be <code>null</code>.
      * @param component the generic playlist component to handle. Shall not be <code>null</code>.
-     * @throws NullPointerException if <code>playlist</code> is <code>null</code>.
-     * @throws NullPointerException if <code>component</code> is <code>null</code>.
-     * @throws Exception if this service provider is unable to represent the input playlist.
      */
-    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component) throws Exception
+    private void addToPlaylist(final Playlist playlist, final AbstractPlaylistComponent component)
     {
         if (component instanceof Sequence)
         {

--- a/src/main/java/christophedelory/plist/Date.java
+++ b/src/main/java/christophedelory/plist/Date.java
@@ -42,7 +42,7 @@ public class Date extends PlistObject
     /**
      * The internal date and time format.
      */
-    private static final DateFormat DATETIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US); // Should not throw NullPointerException, IllegalArgumentException.
+    private static final ThreadLocal<DateFormat> datetimeFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)); // Should not throw NullPointerException, IllegalArgumentException.
 
     /**
      * The date.
@@ -89,10 +89,7 @@ public class Date extends PlistObject
      */
     public java.lang.String getValueString()
     {
-        synchronized(DATETIME_FORMAT)
-        {
-            return DATETIME_FORMAT.format(_value); // Throws NullPointerException if _value is null.
-        }
+        return datetimeFormat.get().format(_value); // Throws NullPointerException if _value is null.
     }
 
     /**
@@ -105,10 +102,7 @@ public class Date extends PlistObject
      */
     public void setValueString(final java.lang.String value) throws ParseException
     {
-        synchronized(DATETIME_FORMAT)
-        {
-            _value = DATETIME_FORMAT.parse(value); // May throw ParseException. Throws NullPointerException if value is null.
-        }
+        _value = datetimeFormat.get().parse(value); // May throw ParseException. Throws NullPointerException if value is null.
     }
 
     /**

--- a/src/main/java/christophedelory/rss/media/BaseMedia.java
+++ b/src/main/java/christophedelory/rss/media/BaseMedia.java
@@ -224,7 +224,7 @@ public class BaseMedia
      */
     public boolean isMediaAdult()
     {
-        return (_mediaAdult == null) ? false : _mediaAdult.booleanValue();
+        return _mediaAdult != null && _mediaAdult.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/rss/media/Content.java
+++ b/src/main/java/christophedelory/rss/media/Content.java
@@ -534,7 +534,8 @@ public class Content extends BaseMedia
      */
     public boolean isDefault()
     {
-        return (_isDefault == null) ? false /*FIXME TBC*/ : _isDefault.booleanValue();
+        /*FIXME TBC*/
+        return _isDefault != null && _isDefault.booleanValue();
     }
 
     /**

--- a/src/main/java/christophedelory/rss/media/Copyright.java
+++ b/src/main/java/christophedelory/rss/media/Copyright.java
@@ -127,10 +127,11 @@ public class Copyright
     }
 
     /**
-     * 
+     *See {@link #getValue}.
+ 
      * @param value the copyright information. Shall not be <code>null</code>.
      * @throws NullPointerException if <code>value</code> is <code>null</code>.
-     * @see #getValue
+     * 
      */
     public void setValue(final String value)
     {

--- a/src/main/java/christophedelory/xml/XmlSerializer.java
+++ b/src/main/java/christophedelory/xml/XmlSerializer.java
@@ -24,23 +24,26 @@
  */
 package christophedelory.xml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
-import java.util.Hashtable;
-
-import org.xml.sax.InputSource;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.exolab.castor.mapping.Mapping;
 import org.exolab.castor.mapping.MappingException;
 import org.exolab.castor.xml.Marshaller;
 import org.exolab.castor.xml.Unmarshaller;
+import org.xml.sax.InputSource;
 
 /**
  * A collection of utilities when manipulating the Castor framework.
@@ -53,7 +56,7 @@ public final class XmlSerializer
     /**
      * The list of mappings already built.
      */
-    private static Hashtable<String,XmlSerializer> _mappings = new Hashtable<String,XmlSerializer>();
+    private static final Map<String,XmlSerializer> _mappings = new LinkedHashMap<>();
 
     /**
      * Retrieves the XML serializer instance associated to the specified package name.
@@ -213,7 +216,7 @@ public final class XmlSerializer
      */
     public void marshal(final Object o, final String fileName, final boolean asDocument) throws Exception
     {
-        final FileWriter out = new FileWriter(fileName, false); // May throw IOException.
+        final Writer out = Files.newBufferedWriter(Paths.get(fileName), UTF_8); // May throw IOException.
         marshal(o, out, asDocument); // May throw MappingException, MarshalException, ValidationException.
         out.flush(); // May throw IOException.
         out.close(); // May throw IOException.
@@ -236,7 +239,7 @@ public final class XmlSerializer
      */
     public void marshal(final Object o, final File file, final boolean asDocument) throws Exception
     {
-        final FileWriter out = new FileWriter(file, false); // May throw IOException.
+        final Writer out = Files.newBufferedWriter(file.toPath(), UTF_8); // May throw IOException.
         marshal(o, out, asDocument); // May throw MappingException, MarshalException, ValidationException.
         out.flush(); // May throw IOException.
         out.close(); // May throw IOException.

--- a/src/test/java/christophedelory/TranscodeTests.java
+++ b/src/test/java/christophedelory/TranscodeTests.java
@@ -41,7 +41,20 @@ public class TranscodeTests
         transcode(samplePath);
       } catch(Exception e) {
         fail(String.format("Transconding of \"%s\" failed", samplePath));
+
       }
+    }
+  }
+
+  @Test
+  public void transcodeAtomPlaylist() throws Exception
+  {
+    List<Path> samples = getSamplePaths().stream()
+      .filter(sample -> sample.toString().endsWith("test02.atom"))
+      .collect(Collectors.toList());
+
+    for(Path samplePath: samples) {
+      transcode(samplePath);
     }
   }
 

--- a/test/AddToPlaylist.sh
+++ b/test/AddToPlaylist.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-root=`dirname $0`
+root=`dirname "$0"`
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$root/lib
-java -cp "$root/lizzy.jar:$root/lib/args4j.jar:$root/classes" christophedelory.lizzy.AddToPlaylist $*
+java -cp "$root/lizzy.jar:$root/lib/args4j.jar:$root/classes" christophedelory.lizzy.AddToPlaylist "$*"

--- a/test/ContentTypeInfo.sh
+++ b/test/ContentTypeInfo.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-root=`dirname $0`
-java -cp "$root/lizzy.jar:$root/classes" christophedelory.lizzy.ContentTypeInfo $*
+root=`dirname "$0"`
+java -cp "$root/lizzy.jar:$root/classes" christophedelory.lizzy.ContentTypeInfo "$*"


### PR DESCRIPTION
Changes:
* Simplifies expressions with binary operators
* Remove fully qualified Object references, use `import` instead
* Remove unnecessary `throws`  
* Remove, presumably unused / not required to import directly, dependencies:
   * `asm:asm:3.3.1`
   * `commons-beanutils:commons-beanutils-core:1.8.3`
   * `commons-collections:commons-collections:3.2.2`
   * `commons-jexl:commons-jexl:1.0`
   * `org.dom4j:dom4j:2.1.4`
   * `xml-apis:xml-apis:1.4.01`
   * `com.sun.activation:javax.activation:1.2.0`