### PR TITLE
Stop normalizing URLs and file-paths to Unix style path

### DIFF
--- a/src/main/java/christophedelory/content/Content.java
+++ b/src/main/java/christophedelory/content/Content.java
@@ -101,7 +101,7 @@ public class Content
      */
     public Content(final String url)
     {
-        _urlString = url.trim().replace('\\', '/'); // Throws NullPointerException if url is null.
+        _urlString = url.trim(); // Throws NullPointerException if url is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/asx/URLElement.java
+++ b/src/main/java/christophedelory/playlist/asx/URLElement.java
@@ -62,6 +62,6 @@ public abstract class URLElement extends AsxElement
      */
     public void setHref(final String href)
     {
-        _href = href.trim().replace('\\', '/'); // Throws NullPointerException if href is null.
+        _href = href.trim(); // Throws NullPointerException if href is null.
     }
 }

--- a/src/main/java/christophedelory/playlist/b4s/Entry.java
+++ b/src/main/java/christophedelory/playlist/b4s/Entry.java
@@ -74,7 +74,7 @@ public class Entry
      */
     public void setPlaystring(final String playstring)
     {
-        _playstring = playstring.trim().replace('\\', '/'); // Throws NullPointerException if playstring is null.
+        _playstring = playstring.trim(); // Throws NullPointerException if playstring is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/m3u/Resource.java
+++ b/src/main/java/christophedelory/playlist/m3u/Resource.java
@@ -88,7 +88,7 @@ public class Resource
      */
     public void setLocation(final String location)
     {
-        _location = location.trim().replace('\\', '/'); // Throws NullPointerException if location is null.
+        _location = location.trim(); // Throws NullPointerException if location is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/rmp/Provider.java
+++ b/src/main/java/christophedelory/playlist/rmp/Provider.java
@@ -126,7 +126,6 @@ public class Provider
     public void setUrlString(final String url)
     {
         _url = StringUtils.normalize(url);
-        //_url = url.trim().replace('\\', '/'); // Throws NullPointerException if url is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/rmp/Track.java
+++ b/src/main/java/christophedelory/playlist/rmp/Track.java
@@ -183,7 +183,6 @@ public class Track
     public void setUrlString(final String url)
     {
         _url = StringUtils.normalize(url);
-        //_url = url.trim().replace('\\', '/'); // Throws NullPointerException if url is null.
     }
 
     /**
@@ -514,7 +513,6 @@ public class Track
     public void setContextInfoUrlString(final String url)
     {
         _contextInfoUrl = StringUtils.normalize(url);
-        //_contextInfoUrl = url.trim().replace('\\', '/'); // Throws NullPointerException if url is null.
     }
 
     /**

--- a/src/main/java/christophedelory/playlist/smil/Reference.java
+++ b/src/main/java/christophedelory/playlist/smil/Reference.java
@@ -98,7 +98,7 @@ public class Reference extends AbstractSmilElement
         }
         else
         {
-            _source = source.trim().replace('\\', '/');
+            _source = source.trim();
         }
     }
 

--- a/src/main/java/christophedelory/playlist/wpl/Media.java
+++ b/src/main/java/christophedelory/playlist/wpl/Media.java
@@ -76,7 +76,7 @@ public class Media
      */
     public void setSource(final String source)
     {
-        _source = source.trim().replace('\\', '/'); // Throws NullPointerException if source is null.
+        this._source = source;
     }
 
     /**


### PR DESCRIPTION
Stop normalizing URLs and file-paths to Unix style path (`/`).

Also [M3U playlist](https://en.wikipedia.org/wiki/M3U) were normalized to Unix style path (`/`)., e.g.:
`C:/Users/maarten/Music`

Although there is no clear definition how file path should be written in M3U entries, this playlist originates from the Windows platform. So forcing Windows path to end up as kind of Unix path, seems not to be incorrect.