### PR TITLE
Move common XML pre-processing to AbstractPlaylistProvider

### DIFF
--- a/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
+++ b/src/main/java/christophedelory/playlist/AbstractPlaylistProvider.java
@@ -1,8 +1,11 @@
 package christophedelory.playlist;
 
+import christophedelory.io.IOUtils;
+import christophedelory.xml.XmlSerializer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 public abstract class AbstractPlaylistProvider implements SpecificPlaylistProvider
@@ -16,6 +19,49 @@ public abstract class AbstractPlaylistProvider implements SpecificPlaylistProvid
   @Override
   public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws Exception {
     return this.readFrom(in, encoding, logger);
+  }
+
+  @Override
+  public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
+  {
+    // Unmarshal the WPL playlist.
+    final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/xspf"); // May throw Exception.
+    serializer.getUnmarshaller().setIgnoreExtraElements(true);
+
+    final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(in); // May throw Exception.
+    ret.setProvider(this);
+
+    return ret;
+  }
+
+  protected final String preProcessXml(final InputStream in, final String encoding) throws IOException
+  {
+    String enc = encoding;
+
+    if (enc == null)
+    {
+      enc = "UTF-8";
+    }
+
+    String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
+
+    // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
+    // First replace blindly all '&' to its corresponding character reference.
+    str = str.replace("&", "&amp;");
+    // Then restore any existing character reference.
+    str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
+
+    // Workaround Castor bug 2521:
+    str = str.replace("xmlns=\"http://www.w3.org/2005/Atom\"", "");
+
+    // An XML element name cannot begin with a digit (like in "0").
+    // Thus the document we are about to parse is NOT well-formed.
+    // But I can't set the "well-formed" parameter to the DOMConfiguration before parsing, nor call setStrictErrorChecking(false).
+    // Thus this trick.
+    str = str.replaceAll("<([0-9]+) ", "<x$1 "); // Shall not throw PatternSyntaxException.
+    str = str.replaceAll("</([0-9]+)", "</x$1"); // Shall not throw PatternSyntaxException.
+
+    return str;
   }
 
 }

--- a/src/main/java/christophedelory/playlist/asx/AsxProvider.java
+++ b/src/main/java/christophedelory/playlist/asx/AsxProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -106,20 +105,8 @@ public class AsxProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8"; // FIXME US-ASCII?
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
         // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
+        String str = preProcessXml(in, encoding);
 
         // Convert all XML element/attribute names to lower case.
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/christophedelory/playlist/atom/AtomProvider.java
+++ b/src/main/java/christophedelory/playlist/atom/AtomProvider.java
@@ -41,7 +41,6 @@ import christophedelory.atom.Person;
 import christophedelory.atom.TextContainer;
 import christophedelory.atom.URIContainer;
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.Version;
 import christophedelory.xml.XmlSerializer;
@@ -85,29 +84,11 @@ public class AtomProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
-        // Workaround Castor bug 2521:
-        str = str.replace("xmlns=\"http://www.w3.org/2005/Atom\"", "");
-
         // Unmarshal the SMIL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/atom"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(true);
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         // TODO Allow also an Entry.
         final Feed feed = (Feed) serializer.unmarshal(reader); // May throw Exception.
 

--- a/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
+++ b/src/main/java/christophedelory/playlist/b4s/B4sProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -78,26 +77,11 @@ public class B4sProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the B4S playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/b4s"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(false); // Force an error if unknown elements are found.
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(reader); // May throw Exception.
         ret.setProvider(this);
 

--- a/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
+++ b/src/main/java/christophedelory/playlist/hypetape/HypetapeProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -75,26 +74,11 @@ public class HypetapeProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the WPL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/hypetape"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(false);
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(reader); // May throw Exception.
         ret.setProvider(this);
 

--- a/src/main/java/christophedelory/playlist/kpl/KplProvider.java
+++ b/src/main/java/christophedelory/playlist/kpl/KplProvider.java
@@ -43,7 +43,6 @@ import org.w3c.dom.NodeList;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.Version;
 
@@ -89,30 +88,8 @@ public class KplProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
-        // An XML element name cannot begin with a digit (like in "0").
-        // Thus the document we are about to parse is NOT well-formed.
-        // But I can't set the "well-formed" parameter to the DOMConfiguration before parsing, nor call setStrictErrorChecking(false).
-        // Thus this trick.
-        str = str.replaceAll("<([0-9]+) ", "<x$1 "); // Shall not throw PatternSyntaxException.
-        str = str.replaceAll("</([0-9]+)", "</x$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the KPL playlist.
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
 
         final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance(); // May throw FactoryConfigurationError.
         final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder(); // May throw ParserConfigurationException.

--- a/src/main/java/christophedelory/playlist/plist/PlistProvider.java
+++ b/src/main/java/christophedelory/playlist/plist/PlistProvider.java
@@ -32,7 +32,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.plist.Array;
 import christophedelory.plist.Dict;
@@ -82,26 +81,11 @@ public class PlistProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/plist"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(false); // Force an error if unknown elements are found.
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final Plist plist = (Plist) serializer.unmarshal(reader); // May throw Exception.
 
         final PlistPlaylist ret = new PlistPlaylist();

--- a/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
+++ b/src/main/java/christophedelory/playlist/rmp/RmpProvider.java
@@ -34,7 +34,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.Version;
 
@@ -80,23 +79,8 @@ public class RmpProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the RMP playlist.
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final JAXBContext jc = JAXBContext.newInstance("christophedelory.playlist.rmp"); // May throw JAXBException.
         final Unmarshaller unmarshaller = jc.createUnmarshaller(); // May throw JAXBException.
         final SpecificPlaylist ret = (SpecificPlaylist) unmarshaller.unmarshal(reader); // May throw JAXBException, UnmarshalException. Shall not throw IllegalArgumentException.

--- a/src/main/java/christophedelory/playlist/rss/RSSProvider.java
+++ b/src/main/java/christophedelory/playlist/rss/RSSProvider.java
@@ -34,7 +34,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.rss.Channel;
 import christophedelory.rss.Enclosure;
@@ -89,26 +88,11 @@ public class RSSProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the SMIL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/rss"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(true);
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final RSS rss = (RSS) serializer.unmarshal(reader); // May throw Exception.
 
         final RSSPlaylist ret = new RSSPlaylist();

--- a/src/main/java/christophedelory/playlist/smil/SmilProvider.java
+++ b/src/main/java/christophedelory/playlist/smil/SmilProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -79,26 +78,11 @@ public class SmilProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the SMIL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/smil"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(true); // Many SMIL elements are not implemented yet.
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(reader); // May throw Exception.
         ret.setProvider(this);
 

--- a/src/main/java/christophedelory/playlist/wpl/WplProvider.java
+++ b/src/main/java/christophedelory/playlist/wpl/WplProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -77,26 +76,11 @@ public class WplProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the WPL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/wpl"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(false); // Force an error if unknown elements are found.
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(reader); // May throw Exception.
         ret.setProvider(this);
 

--- a/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
+++ b/src/main/java/christophedelory/playlist/xspf/XspfProvider.java
@@ -31,7 +31,6 @@ import christophedelory.playlist.*;
 import org.apache.commons.logging.Log;
 
 import christophedelory.content.type.ContentType;
-import christophedelory.io.IOUtils;
 import christophedelory.player.PlayerSupport;
 import christophedelory.xml.XmlSerializer;
 
@@ -79,26 +78,11 @@ public class XspfProvider extends AbstractPlaylistProvider
     @Override
     public SpecificPlaylist readFrom(final InputStream in, final String encoding, final Log logger) throws Exception
     {
-        String enc = encoding;
-
-        if (enc == null)
-        {
-            enc = "UTF-8";
-        }
-
-        String str = IOUtils.toString(in, enc); // May throw IOException. Throws NullPointerException if in is null.
-
-        // Replace all occurrences of a single '&' with "&amp;" (or leave this construct as is).
-        // First replace blindly all '&' to its corresponding character reference.
-        str = str.replace("&", "&amp;");
-        // Then restore any existing character reference.
-        str = str.replaceAll("&amp;([a-zA-Z0-9#]+;)", "&$1"); // Shall not throw PatternSyntaxException.
-
         // Unmarshal the WPL playlist.
         final XmlSerializer serializer = XmlSerializer.getMapping("christophedelory/playlist/xspf"); // May throw Exception.
         serializer.getUnmarshaller().setIgnoreExtraElements(true);
 
-        final StringReader reader = new StringReader(str);
+        final StringReader reader = new StringReader(preProcessXml(in, encoding));
         final SpecificPlaylist ret = (SpecificPlaylist) serializer.unmarshal(reader); // May throw Exception.
         ret.setProvider(this);
 


### PR DESCRIPTION
Essentially refactoring to reduce duplicate code, by moving (nearly) common XML pre-processing from the XML playlist provider code to the `AbstractPlaylistProvider`.
