### PR TITLE
Prevent using obsolete internal Sun JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     //JAXB RI, Jakarta XML Binding
     runtimeOnly 'com.sun.xml.bind:jaxb-impl:2.3.8'
 
+    // Can be reomved with castor-xml dependency
+    // https://mvnrepository.com/artifact/xerces/xercesImpl
+    runtimeOnly 'xerces:xercesImpl:2.12.2'
+
     // JUnit Jupiter using Gradle's native JUnit Platform
     testImplementation platform('org.junit:junit-bom:5.9.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/src/main/java/christophedelory/xml/XmlSerializer.java
+++ b/src/main/java/christophedelory/xml/XmlSerializer.java
@@ -26,13 +26,7 @@ package christophedelory.xml;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -43,6 +37,7 @@ import org.exolab.castor.mapping.Mapping;
 import org.exolab.castor.mapping.MappingException;
 import org.exolab.castor.xml.Marshaller;
 import org.exolab.castor.xml.Unmarshaller;
+import org.exolab.castor.xml.XMLContext;
 import org.xml.sax.InputSource;
 
 /**
@@ -316,7 +311,21 @@ public final class XmlSerializer
         _unmarshaller.setValidation(false);
         _unmarshaller.setIgnoreExtraElements(true);
 
-        _marshaller = new Marshaller();
+
+        StringWriter myWriter= new StringWriter();
+        XMLContext xmlContext = new XMLContext();
+        xmlContext.setProperty(org.castor.xml.XMLProperties.SERIALIZER_FACTORY,
+            org.exolab.castor.xml.XercesXMLSerializerFactory.class.getName());
+        _marshaller = xmlContext.createMarshaller();
+        try
+        {
+            _marshaller.setWriter(myWriter);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+
         _marshaller.setMapping(mapping); // May throw MappingException.
         _marshaller.setValidation(false);
         //_marshaller.setDebug(true);


### PR DESCRIPTION
Prevent using obsolete internal Sun JDK `com.sun.org.apache.xml.internal.serialize.XMLSerializer`