### PR TITLE
Be able to read from `Path`

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "gradle"
-jdkVersion = "15"
+jdkVersion = "17"
 
 ignoreRules = ["PATH_TRAVERSAL_IN"]

--- a/src/main/java/io/github/borewit/lizzy/playlist/AbstractPlaylist.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/AbstractPlaylist.java
@@ -1,0 +1,14 @@
+package io.github.borewit.lizzy.playlist;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public abstract class AbstractPlaylist implements SpecificPlaylist
+{
+  @Override
+  public void writeTo(OutputStream out) throws IOException
+  {
+    this.writeTo(out, null);
+  }
+
+}

--- a/src/main/java/io/github/borewit/lizzy/playlist/AbstractPlaylistProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/AbstractPlaylistProvider.java
@@ -15,15 +15,16 @@ public abstract class AbstractPlaylistProvider implements SpecificPlaylistProvid
 {
   private final Logger logger = LogManager.getLogger(AbstractPlaylistProvider.class);
 
-  public SpecificPlaylist readFrom(final InputStream in) throws IOException
+  @Override
+  public SpecificPlaylist readFrom(final InputStream inputStream) throws IOException
   {
-    return this.readFrom(in, null);
+    return this.readFrom(inputStream, null);
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
-    return this.readFrom(in, encoding);
+    return this.readFrom(inputStream, encoding);
   }
 
   protected final InputStreamReader preProcessXml(final InputStream in, final String encoding)

--- a/src/main/java/io/github/borewit/lizzy/playlist/SpecificPlaylist.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/SpecificPlaylist.java
@@ -56,6 +56,18 @@ public interface SpecificPlaylist
   void writeTo(OutputStream out, String encoding) throws IOException;
 
   /**
+   * Writes this specific playlist to the specified output stream, using default encoding
+   * When done, the stream may be flushed, but not closed.
+   *
+   * @param out      an output stream. Shall not be <code>null</code>.
+   * @throws NullPointerException if <code>out</code> is <code>null</code>.
+   * @throws Exception            if any error occurs during the marshalling process.
+   * @see SpecificPlaylistFactory#readFrom
+   * @see SpecificPlaylistProvider#readFrom
+   */
+  void writeTo(OutputStream out) throws IOException;
+
+  /**
    * Builds a generic representation from this specific playlist.
    *
    * @return a generic playlist. Shall not be <code>null</code>.

--- a/src/main/java/io/github/borewit/lizzy/playlist/SpecificPlaylistProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/SpecificPlaylistProvider.java
@@ -54,25 +54,25 @@ public interface SpecificPlaylistProvider
   ContentType[] getContentTypes();
 
   /**
-   * Reads a playlist from the specified input stream.
+   * Reads a playlist from the specified input-stream.
    * When done, the stream remains open.
    *
-   * @param in an input stream. Shall not be <code>null</code>.
+   * @param inputStream an input stream. Shall not be <code>null</code>.
    * @return a new playlist instance, or <code>null</code> if the format has been recognized, but the playlist is malformed.
    * @throws NullPointerException if <code>in</code> is <code>null</code>.
    * @throws NullPointerException if <code>logger</code> is <code>null</code>.
-   * @throws Exception            if any error occurs during the unmarshalling process.
+   * @throws IOException          if any error occurs during the unmarshalling process.
    * @see SpecificPlaylist#writeTo
    * @see SpecificPlaylistFactory#readFrom
    */
-  SpecificPlaylist readFrom(InputStream in) throws IOException;
+  SpecificPlaylist readFrom(InputStream inputStream) throws IOException;
 
   /**
    * Reads a playlist from the specified input stream.
    * When done, the stream remains open.
    *
-   * @param in       an input stream. Shall not be <code>null</code>.
-   * @param encoding the content encoding of the input resource, or <code>null</code> if not known.
+   * @param inputStream an input stream. Shall not be <code>null</code>.
+   * @param encoding    the content encoding of the input resource, or <code>null</code> if not known.
    * @return a new playlist instance, or <code>null</code> if the format has been recognized, but the playlist is malformed.
    * @throws NullPointerException if <code>in</code> is <code>null</code>.
    * @throws NullPointerException if <code>logger</code> is <code>null</code>.
@@ -81,7 +81,7 @@ public interface SpecificPlaylistProvider
    * @see SpecificPlaylistFactory#readFrom
    * @see SpecificPlaylist#writeTo
    */
-  SpecificPlaylist readFrom(InputStream in, String encoding) throws IOException;
+  SpecificPlaylist readFrom(InputStream inputStream, String encoding) throws IOException;
 
   /**
    * Builds a specific representation of the given generic playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/asx/AsxPlaylistAdapter.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/asx/AsxPlaylistAdapter.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.asx;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.Sequence;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.playlist.asx.*;
 
 import java.io.IOException;
@@ -41,7 +38,7 @@ import java.io.OutputStream;
  * @author Borewit
  * @author Christophe Delory
  */
-public class AsxPlaylistAdapter implements SpecificPlaylist
+public class AsxPlaylistAdapter extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/asx/AsxProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/asx/AsxProvider.java
@@ -107,11 +107,11 @@ public class AsxProvider extends JaxbPlaylistProvider<Asx>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<Asx> asx = this.unmarshal(in, encoding);
+      final JAXBElement<Asx> asx = this.unmarshal(inputStream, encoding);
       String rootElementName = asx.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("ASX") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/atom/AtomPlaylist.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/atom/AtomPlaylist.java
@@ -25,9 +25,9 @@
 package io.github.borewit.lizzy.playlist.atom;
 
 import io.github.borewit.lizzy.content.Content;
+import io.github.borewit.lizzy.playlist.AbstractPlaylist;
 import io.github.borewit.lizzy.playlist.Media;
 import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
 import io.github.borewit.playlist.atom.EntryType;
 import io.github.borewit.playlist.atom.FeedType;
 import io.github.borewit.playlist.atom.Link;
@@ -42,7 +42,7 @@ import java.io.OutputStream;
  * @author Borewit
  * @author Christophe Delory
  */
-public class AtomPlaylist implements SpecificPlaylist
+public class AtomPlaylist extends AbstractPlaylist
 {
   /**
    * The Atom playlist provider

--- a/src/main/java/io/github/borewit/lizzy/playlist/atom/AtomProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/atom/AtomProvider.java
@@ -81,11 +81,11 @@ public class AtomProvider extends JaxbPlaylistProvider<FeedType>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<FeedType> feed = this.unmarshal(in, encoding);
+      final JAXBElement<FeedType> feed = this.unmarshal(inputStream, encoding);
       String rootElementName = feed.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("Feed") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/b4s/WinampXmlAdapter.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/b4s/WinampXmlAdapter.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.b4s;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.playlist.b4s.WinampXML;
 
 import java.io.IOException;
@@ -40,7 +37,7 @@ import java.io.OutputStream;
  * @author Borewit
  * @author Christophe Delory
  */
-public class WinampXmlAdapter implements SpecificPlaylist
+public class WinampXmlAdapter extends AbstractPlaylist
 {
   private final WinampXML winampXML;
 

--- a/src/main/java/io/github/borewit/lizzy/playlist/b4s/WinampXmlProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/b4s/WinampXmlProvider.java
@@ -78,11 +78,11 @@ public class WinampXmlProvider extends JaxbPlaylistProvider<WinampXML>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<WinampXML> winampXMLJAXBElement = this.unmarshal(in, encoding);
+      final JAXBElement<WinampXML> winampXMLJAXBElement = this.unmarshal(inputStream, encoding);
       String rootElementName = winampXMLJAXBElement.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("WinampXML") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/m3u/M3U.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/m3u/M3U.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.m3u;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -43,7 +40,7 @@ import java.util.List;
  * @author Christophe Delory
  * @version $Revision: 92 $
  */
-public class M3U implements SpecificPlaylist
+public class M3U extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/m3u/M3UProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/m3u/M3UProvider.java
@@ -102,7 +102,7 @@ public class M3UProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     String enc = encoding;
 
@@ -112,7 +112,7 @@ public class M3UProvider extends AbstractPlaylistProvider
     }
 
 
-    BOMInputStream bomInputStream = wrapInBomStream(in);
+    BOMInputStream bomInputStream = wrapInBomStream(inputStream);
 
     if (bomInputStream.hasBOM())
     {

--- a/src/main/java/io/github/borewit/lizzy/playlist/mpcpl/MPCPL.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/mpcpl/MPCPL.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.mpcpl;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -44,7 +41,7 @@ import java.util.List;
  * @version $Revision: 91 $
  * @since 0.3.0
  */
-public class MPCPL implements SpecificPlaylist
+public class MPCPL extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/mpcpl/MPCPLProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/mpcpl/MPCPLProvider.java
@@ -74,7 +74,7 @@ public class MPCPLProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     String enc = encoding;
 
@@ -83,7 +83,7 @@ public class MPCPLProvider extends AbstractPlaylistProvider
       enc = "UTF-8"; // FIXME US-ASCII?
     }
 
-    final BufferedReader reader = new BufferedReader(new InputStreamReader(in, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
 
     MPCPL ret = new MPCPL();
     ret.setProvider(this);

--- a/src/main/java/io/github/borewit/lizzy/playlist/pla/PLA.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/pla/PLA.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.pla;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,7 +41,7 @@ import java.util.List;
  * @version $Revision: 91 $
  * @since 0.2.0
  */
-public class PLA implements SpecificPlaylist
+public class PLA extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/pla/PLAProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/pla/PLAProvider.java
@@ -72,7 +72,7 @@ public class PLAProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     PLA ret = new PLA();
     ret.setProvider(this);
@@ -81,7 +81,7 @@ public class PLAProvider extends AbstractPlaylistProvider
     // A conforming playlist file consists of 1+N null-padded 512-byte frames, where N is the number of songs in the playlist.
     final byte[] array = new byte[512];
 
-    if (in.read(array) != 512) // Throws NullPointerException if in is null. May throw IOException.
+    if (inputStream.read(array) != 512) // Throws NullPointerException if in is null. May throw IOException.
     {
       throw new IllegalArgumentException("Not a PLA playlist format (file too small)");
     }
@@ -105,7 +105,7 @@ public class PLAProvider extends AbstractPlaylistProvider
 
     for (int i = 0; i < nbSongs; i++)
     {
-      if (in.read(array) != 512) // May throw IOException.
+      if (inputStream.read(array) != 512) // May throw IOException.
       {
         logger.error("Malformed PLA playlist (file too small)");
         ret = null;

--- a/src/main/java/io/github/borewit/lizzy/playlist/plist/PlistPlaylist.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/plist/PlistPlaylist.java
@@ -26,10 +26,7 @@ package io.github.borewit.lizzy.playlist.plist;
 
 import com.dd.plist.*;
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.Sequence;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
+import io.github.borewit.lizzy.playlist.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,10 +35,11 @@ import java.util.Date;
 /**
  * The definition of an iTunes playlist.
  *
+ * @author Borewit
  * @author Christophe Delory
  * @version $Revision: 92 $
  */
-public class PlistPlaylist implements SpecificPlaylist
+public class PlistPlaylist extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/plist/PlistProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/plist/PlistProvider.java
@@ -71,12 +71,12 @@ public class PlistProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     NSDictionary plist;
     try
     {
-      plist = (NSDictionary) PropertyListParser.parse(in);
+      plist = (NSDictionary) PropertyListParser.parse(inputStream);
     }
     catch (Exception e)
     {

--- a/src/main/java/io/github/borewit/lizzy/playlist/plp/PLP.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/plp/PLP.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.plp;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -40,11 +37,12 @@ import java.util.List;
 /**
  * Music playlist for a SanDisk Sansa portable media player.
  *
+ * @author Borewit
  * @author Christophe Delory
  * @version $Revision: 92 $
  * @since 0.2.0
  */
-public class PLP implements SpecificPlaylist
+public class PLP extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/plp/PLPProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/plp/PLPProvider.java
@@ -73,7 +73,7 @@ public class PLPProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     String enc = encoding;
 
@@ -82,7 +82,7 @@ public class PLPProvider extends AbstractPlaylistProvider
       enc = "UTF-16LE";
     }
 
-    final BufferedReader reader = new BufferedReader(new InputStreamReader(in, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
 
     PLP ret = new PLP();
     ret.setProvider(this);

--- a/src/main/java/io/github/borewit/lizzy/playlist/pls/PLS.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/pls/PLS.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.pls;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.lizzy.playlist.m3u.Resource;
 
 import java.io.BufferedWriter;
@@ -59,10 +56,11 @@ import java.util.List;
  * </ul>
  * </ul>
  *
+ * @author Borewit
  * @author Christophe Delory
  * @version $Revision: 91 $
  */
-public class PLS implements SpecificPlaylist
+public class PLS extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/pls/PLSProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/pls/PLSProvider.java
@@ -85,7 +85,7 @@ public class PLSProvider extends AbstractPlaylistProvider
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     String enc = encoding;
 
@@ -94,7 +94,7 @@ public class PLSProvider extends AbstractPlaylistProvider
       enc = "UTF-8"; // FIXME US-ASCII?
     }
 
-    final BufferedReader reader = new BufferedReader(new InputStreamReader(in, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, enc)); // Throws NullPointerException if in is null. May throw UnsupportedEncodingException, IOException.
 
     PLS ret = new PLS();
     ret.setProvider(this);

--- a/src/main/java/io/github/borewit/lizzy/playlist/rmp/RmpPlaylistAdapter.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/rmp/RmpPlaylistAdapter.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.rmp;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.JaxbPlaylistProvider;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.playlist.rmp.RmpPackage;
 
 import java.io.IOException;
@@ -41,7 +38,7 @@ import java.io.OutputStream;
  * @author Christophe Delory
  * @since 0.3.0
  */
-public class RmpPlaylistAdapter implements SpecificPlaylist
+public class RmpPlaylistAdapter extends AbstractPlaylist
 {
   private RmpProvider provider;
   private final RmpPackage rmpPackage;

--- a/src/main/java/io/github/borewit/lizzy/playlist/rmp/RmpProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/rmp/RmpProvider.java
@@ -79,12 +79,12 @@ public class RmpProvider extends JaxbPlaylistProvider<RmpPackage>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
       final String rmpEncoding = encoding == null ? StandardCharsets.US_ASCII.toString() : encoding;
-      final JAXBElement<RmpPackage> rmp = this.unmarshal(in, rmpEncoding);
+      final JAXBElement<RmpPackage> rmp = this.unmarshal(inputStream, rmpEncoding);
       String rootElementName = rmp.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("PACKAGE") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/rss/RSSPlaylist.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/rss/RSSPlaylist.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.rss;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.Sequence;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.playlist.rss20.Enclosure;
 import io.github.borewit.playlist.rss20.Item;
 import io.github.borewit.playlist.rss20.ObjectFactory;
@@ -45,7 +42,7 @@ import java.io.OutputStream;
  * @author Borewit
  * @author Christophe Delory
  */
-public class RSSPlaylist implements SpecificPlaylist
+public class RSSPlaylist extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/rss/RSSProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/rss/RSSProvider.java
@@ -87,11 +87,11 @@ public class RSSProvider extends JaxbPlaylistProvider<Rss>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<Rss> rssJAXBElement = this.unmarshal(in, encoding);
+      final JAXBElement<Rss> rssJAXBElement = this.unmarshal(inputStream, encoding);
       String rootElementName = rssJAXBElement.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("RSS") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/smil20/SmilAdapter.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/smil20/SmilAdapter.java
@@ -37,7 +37,7 @@ import java.io.OutputStream;
  * @author Borewit
  * @author Christophe Delory
  */
-public class SmilAdapter implements SpecificPlaylist
+public class SmilAdapter extends AbstractPlaylist
 {
   /**
    * The provider of this specific playlist.

--- a/src/main/java/io/github/borewit/lizzy/playlist/smil20/SmilProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/smil20/SmilProvider.java
@@ -82,11 +82,11 @@ public class SmilProvider extends JaxbPlaylistProvider<Smil>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<Smil> smil = this.unmarshal(in, encoding);
+      final JAXBElement<Smil> smil = this.unmarshal(inputStream, encoding);
       String rootElementName = smil.getName().getLocalPart();
 
       return rootElementName != null && rootElementName.equalsIgnoreCase("smil") ?

--- a/src/main/java/io/github/borewit/lizzy/playlist/xspf/XspfPlaylistAdapter.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/xspf/XspfPlaylistAdapter.java
@@ -25,10 +25,7 @@
 package io.github.borewit.lizzy.playlist.xspf;
 
 import io.github.borewit.lizzy.content.Content;
-import io.github.borewit.lizzy.playlist.JaxbPlaylistProvider;
-import io.github.borewit.lizzy.playlist.Media;
-import io.github.borewit.lizzy.playlist.Playlist;
-import io.github.borewit.lizzy.playlist.SpecificPlaylist;
+import io.github.borewit.lizzy.playlist.*;
 import io.github.borewit.playlist.xspf.ObjectFactory;
 import io.github.borewit.playlist.xspf.XspfPlaylist;
 import io.github.borewit.playlist.xspf.XspfTrack;
@@ -40,10 +37,10 @@ import java.io.OutputStream;
 /**
  * XSPF, an XML format designed to enable playlist sharing.
  *
+ * @author Borewit
  * @author Christophe Delory
- * @version $Revision: 91 $
  */
-public class XspfPlaylistAdapter implements SpecificPlaylist
+public class XspfPlaylistAdapter extends AbstractPlaylist
 {
 
   /**

--- a/src/main/java/io/github/borewit/lizzy/playlist/xspf/XspfProvider.java
+++ b/src/main/java/io/github/borewit/lizzy/playlist/xspf/XspfProvider.java
@@ -82,11 +82,11 @@ public class XspfProvider extends JaxbPlaylistProvider<XspfPlaylist>
   }
 
   @Override
-  public SpecificPlaylist readFrom(final InputStream in, final String encoding) throws IOException
+  public SpecificPlaylist readFrom(final InputStream inputStream, final String encoding) throws IOException
   {
     try
     {
-      final JAXBElement<XspfPlaylist> xspfPlaylist = this.unmarshal(in, encoding);
+      final JAXBElement<XspfPlaylist> xspfPlaylist = this.unmarshal(inputStream, encoding);
       String rootElementName = xspfPlaylist.getName().getLocalPart();
       return rootElementName != null && rootElementName.equals("playlist") ?
         new XspfPlaylistAdapter(this, xspfPlaylist.getValue()) : null;

--- a/src/test/java/io/github/borewit/lizzy/playlist/asx/AsxPlaylistTests.java
+++ b/src/test/java/io/github/borewit/lizzy/playlist/asx/AsxPlaylistTests.java
@@ -79,7 +79,7 @@ public class AsxPlaylistTests
       AsxProvider asxProvider = new AsxProvider();
       try
       {
-        SpecificPlaylist specificPlaylist = asxProvider.readFrom(in, null);
+        SpecificPlaylist specificPlaylist = asxProvider.readFrom(in);
         assertNull(specificPlaylist, "ASX provider should return null reading a different XML Type");
       }
       catch (Exception exception)
@@ -96,7 +96,7 @@ public class AsxPlaylistTests
     try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream())
     {
       SpecificPlaylist specificPlaylist = asxProvider.toSpecificPlaylist(playlist);
-      specificPlaylist.writeTo(byteArrayOutputStream, null);
+      specificPlaylist.writeTo(byteArrayOutputStream);
     }
   }
 }

--- a/src/test/java/io/github/borewit/lizzy/util/TestUtil.java
+++ b/src/test/java/io/github/borewit/lizzy/util/TestUtil.java
@@ -60,26 +60,9 @@ public class TestUtil
   public static Playlist readPlaylistFrom(Path playlistPath) throws IOException
   {
     Path absPlaylistPath = playlistPath.isAbsolute() ? playlistPath : sampleFolderPath.resolve(playlistPath);
-    List<SpecificPlaylistProvider> playlistProviders = SpecificPlaylistFactory.getInstance().findProvidersByExtension(absPlaylistPath.toString());
-    assertFalse(playlistProviders.isEmpty(), String.format("Expect to find a provider extension of path %s", absPlaylistPath));
-    for (SpecificPlaylistProvider playlistProvider : playlistProviders)
-    {
-      try (InputStream is = Files.newInputStream(absPlaylistPath))
-      {
-        try
-        {
-          SpecificPlaylist specificPlaylist = playlistProvider.readFrom(is, null);
-          if (specificPlaylist != null)
-            return specificPlaylist.toPlaylist();
-        }
-        catch (IOException e)
-        {
-          throw new IOException(String.format("Failed to read from %s", absPlaylistPath.getFileName()), e);
-        }
-      }
-    }
-    fail(String.format("Failed to find provider which is able to decode playlist path \"%s\"", playlistPath));
-    return null;
+    SpecificPlaylist specificPlaylist = SpecificPlaylistFactory.getInstance().readFrom(absPlaylistPath);
+    assertNotNull(specificPlaylist, String.format("Reading playlist %s", absPlaylistPath.getFileName()));
+    return specificPlaylist.toPlaylist();
   }
 
   public static Map<String, JsonPlaylist> getPlaylistMetadata() throws IOException


### PR DESCRIPTION
Be able to write to playlist using default encoding.

Add following method to `io.github.borewit.lizzy.playlist.SpecificPlaylistFactory`
```java
public SpecificPlaylist readFrom(Path playlistPath, OpenOption... options) throws IOException
```
This allows to open playlist directly from [Java NIO Path](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/nio/file/Path.html).

Add following method to `io.github.borewit.lizzy.playlist.SpecificPlaylist`:
```java
public SpecificPlaylist readFrom(final InputStream inputStream) throws IOException
```