### PR TITLE
Fix inclusion of transitive dependency `org.glassfish.jaxb.runtime`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     // JAXB API only
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
-    // JAXB RI, Jakarta XML Binding
+    // JAXB RI, Jakarta XML Binding (do not change to runtimeOnly, breaks transitive dependency)
     implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.5'
 
     // JUnit Jupiter using Gradle's native JUnit Platform

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module io.github.borewit.lizzy {
   requires jakarta.activation;
   requires org.apache.commons.io;
   requires jakarta.xml.bind;
+  requires org.glassfish.jaxb.runtime; // Add the JAXB RI implementation module
   requires dd.plist;
   requires com.fasterxml.jackson.annotation;
   requires com.fasterxml.jackson.databind;


### PR DESCRIPTION
Fix inclusion of transitive dependency `org.glassfish.jaxb.runtime`