### PR TITLE
Update GitHub workflow actions used in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,17 @@ jobs:
     permissions:
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: corretto
           cache: gradle
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
       - name: Run build with Gradle Wrapper
         run: ./gradlew build
       - name: Test Report


### PR DESCRIPTION
Update GitHub actions:
- Upgrades the checkout action from v3 to v4.
- Updates the setup-java action from v3 to v4.
- Changes the Gradle setup action to gradle/actions/setup-gradle@v4.